### PR TITLE
Downgrade java to 17

### DIFF
--- a/MoreCompose/build.gradle.kts
+++ b/MoreCompose/build.gradle.kts
@@ -28,11 +28,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_22
-        targetCompatibility = JavaVersion.VERSION_22
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "22"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,11 +28,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk22
+  - openjdk17


### PR DESCRIPTION
With Java 22, it need CI server to setup java to the same version.
But when use this library in apps, the extra setup steps might cause subsequent memory issue: **java.lang.VirtualMachineError: Out of space in CodeCache for adapters**

To solve this error, there are two choose:
1. Increase java code cache by add **-XX:ReservedCodeCacheSize=320m** into org.gradle.jvmargs
2. Use default java version on CI rather than using a newer version of java.

This PR try to verify the second choose work.